### PR TITLE
Added required header for `strcmp` function

### DIFF
--- a/src/ph7_wrapper.cpp
+++ b/src/ph7_wrapper.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <string.h>
 #include <node.h>
 #include "ph7_wrapper.h"
 extern "C" {


### PR DESCRIPTION
When I install `ph7`, there is an error occur when compiling ph7

```
../src/ph7_wrapper.cpp:503: error: ‘strcmp’ was not declared in this scope
```

The `strcmp` function is declared in `string.h`

This PR added the required header.
